### PR TITLE
Only replace the dark/light string in body

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -17,7 +17,9 @@ void function() {
   function setTheme(newTheme) {
     window.__theme = newTheme
     preferredTheme = newTheme
-    document.body.className = newTheme
+    document.body.className.match(/dark|light/g).length > 0 
+      ? document.body.classList.replace(/dark|light/g, newTheme)
+      : document.body.classList.add(newTheme)
     window.__onThemeChange(newTheme)
   }
 

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -18,7 +18,7 @@ void function() {
     window.__theme = newTheme
     preferredTheme = newTheme
     document.body.className.match(/dark|light/g) !== null 
-      ? document.body.classList.replace(/dark|light/g, newTheme)
+      ? document.body.classList.replace(newTheme === 'dark' ? 'light' : 'dark', newTheme)
       : document.body.classList.add(newTheme)
     window.__onThemeChange(newTheme)
   }

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -17,7 +17,7 @@ void function() {
   function setTheme(newTheme) {
     window.__theme = newTheme
     preferredTheme = newTheme
-    document.body.className.match(/dark|light/g).length > 0 
+    document.body.className.match(/dark|light/g) !== null 
       ? document.body.classList.replace(/dark|light/g, newTheme)
       : document.body.classList.add(newTheme)
     window.__onThemeChange(newTheme)


### PR DESCRIPTION
### What does it do?
Instead of replacing the complete className of the body, only replace the `dark/light` part. If the dark/light does not exist yet, just add the `newTheme`

### Why?
In some cases you might already have `className` on your body (in my case a "home" class). The current version of this plugin makes your site flash because it first removes the "home" class and later on it is added again by javascript. By only replacing the light/dark part, you will only modify the relevant part of the className and thus no more flashing 🔦 !