### PR TITLE
Fixing unnecessary reflow bug in plugin

### DIFF
--- a/src/ThemeToggler.js
+++ b/src/ThemeToggler.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 class ThemeToggler extends React.Component {
   state = {
-    theme: null,
+    theme: window.__theme,
   }
 
   componentDidMount() {

--- a/src/ThemeToggler.js
+++ b/src/ThemeToggler.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 class ThemeToggler extends React.Component {
   state = {
-    theme: window.__theme,
+    theme: window.__theme
   }
 
   componentDidMount() {


### PR DESCRIPTION
If we set your theme as `light/dark` and reload the page, we won't see anything visually but you can really see this bug if you are doing any animation on your toggle switch based on `theme` value.

Simply console logging the theme value and triggering route change will show this - 
![image](https://s5.gifyu.com/images/19a1ff251f809f568.gif)
which is causing the following visual glitch.
![image](https://s5.gifyu.com/images/temp--too.gif)

Solution: Setting the default value of theme to `window.__theme` ~null~ will fix this issue coz if __theme value is not present, it would default to falsy value now.

If this looks file, I would also request you to do a new `v1.1.1` release with this change.